### PR TITLE
build: add workflow to cleanup coverage directories

### DIFF
--- a/.github/workflows/cleanup_coverage.yml
+++ b/.github/workflows/cleanup_coverage.yml
@@ -1,0 +1,166 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# Workflow name:
+name: cleanup_coverage
+
+# Workflow triggers:
+on:
+  # Run the workflow on the first day of each week:
+  schedule:
+    - cron: '0 0 * * 1'
+
+  # Allow the workflow to be manually run:
+  workflow_dispatch:
+
+# Global permissions:
+permissions:
+  # Allow read-only access to the repository contents:
+  contents: read
+
+# Workflow jobs:
+jobs:
+
+  # Define a job for cleaning up unneeded coverage reports:
+  coverage:
+
+    # Define a display name:
+    name: 'Clean up unneeded coverage reports'
+
+    # Define the type of virtual host machine:
+    runs-on: ubuntu-latest
+
+    # Define the sequence of job steps...
+    steps:
+      # Checkout the repository:
+      - name: 'Checkout repository'
+        # Pin action to full length commit SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Specify whether to remove untracked files before checking out the repository:
+          clean: true
+
+          # Limit clone depth to the most recent commit:
+          fetch-depth: 1
+
+          # Specify whether to download Git-LFS files:
+          lfs: false
+
+          # Avoid storing GitHub token in local Git configuration:
+          persist-credentials: false
+        timeout-minutes: 10
+
+      # Checkout development repository:
+      - name: 'Checkout development repository'
+        # Pin action to full length commit SHA
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Code development repository:
+          repository: 'stdlib-js/stdlib'
+
+          # Branch to checkout:
+          ref: 'develop'
+
+          # File path to checkout to:
+          path: './tmp'
+
+          # Specify whether to remove untracked files before checking out the repository:
+          clean: false
+
+          # Limit clone depth to the most recent commit:
+          fetch-depth: 1
+
+          # Token for accessing the repository:
+          token: ${{ secrets.STDLIB_BOT_FGPAT_REPO_READ }}
+
+          # Avoid storing GitHub token in local Git configuration:
+          persist-credentials: false
+
+      # Find and delete unneeded coverage directories:
+      - name: 'Find and delete unneeded coverage directories'
+        run: |
+          # Find all coverage directories:
+          find . \
+            \( -name .git -prune \) -o \
+            \( -name .github -prune \) -o \
+            \( -name etc -prune \) -o \
+            \( -name lib -prune \) -o \
+            \( -name public -prune \) -o \
+            \( -name server -prune \) -o \
+            \( -name src -prune \) -o \
+            \( -name tmp -prune \) -o \
+            \( -name tools -prune \) -o -type d -print | \
+            sed "s|^.\/||" | \
+            sed "s|^.$||" | \
+            sed -E 's/\/(benchmark|bin|data|docs|etc|examples|include|lib|scripts|src|test)(\/.*)?$//' | \
+            sort -u > coverage_dirs.txt
+
+          # Path to main package directory in development repository:
+          pkg_dir='./tmp/lib/node_modules/@stdlib'
+
+          # Extract all packages currently residing in `pkg_dir`:
+          find $pkg_dir -type d -print | \
+            sed "s|^$pkg_dir/||" | \
+            sed -E 's/\/(benchmark|bin|data|docs|etc|examples|include|lib|scripts|src|test)(\/.*)?$//' | \
+            sort -u > package_dirs.txt
+
+          # Find entries present in `coverage_dir` but not in `package_dirs`:
+          comm -23 coverage_dirs.txt package_dirs.txt > dirs_to_remove.txt
+
+          # Delete directories:
+          while IFS= read -r dir; do
+            rm -r -- "$dir"
+          done < dirs_to_remove.txt
+
+          # Perform clean-up:
+          rm coverage_dirs.txt
+          rm package_dirs.txt
+          rm dirs_to_remove.txt
+
+      # Import GPG key to sign commits:
+      - name: 'Import GPG key to sign commits'
+        # Pin action to full length commit SHA
+        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+        with:
+          gpg_private_key: ${{ secrets.STDLIB_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.STDLIB_BOT_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      # Create a pull request with the changes:
+      - name: 'Create pull request'
+        id: cpr
+        # Pin action to full length commit SHA
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
+        with:
+          title: 'chore: cleanup coverage directories'
+          body: |
+            This PR
+
+            -   removes all coverage directories that do not correspond anymore to packages in the main development repository.
+
+          commit-message: 'chore: cleanup coverage directories'
+          committer: 'stdlib-bot <82920195+stdlib-bot@users.noreply.github.com>'
+          signoff: true
+          token: ${{ secrets.STDLIB_BOT_PAT_REPO_WRITE }}
+          labels: |
+            automated-pr
+          team-reviewers: |
+            reviewers
+          branch: cleanup-coverage-directories
+          delete-branch: true


### PR DESCRIPTION
This PR

-   adds a workflow to periodically check the coverage directories inside this repository against our [development repository](https://github.com/stdlib-js/stdlib). It will create a PR deleting all coverage directories that do not anymore correspond to any packages in the main repository, e.g. because packages were removed or now reside in a different location.

This PR resolves https://github.com/stdlib-js/metr-issue-tracker/issues/10.